### PR TITLE
Patch for sawtooth 1.2.4

### DIFF
--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -27,6 +27,10 @@ impl EventHandler {
 
     pub fn handle_events(&self, data: &[u8]) -> Result<(), SubscriberError> {
         let (block, operations) = self.parse_events(data)?;
+        // Handle empty event from sawtooth-settings-tp heartbeat pings
+        if block.block_id == "" && operations.is_empty() {
+            return Ok::<(), SubscriberError>(());
+        }
         self.data_manager
             .execute_operations_in_block(operations, &block)?;
         info!("Successfully submited event data to reporting database");
@@ -36,6 +40,16 @@ impl EventHandler {
     fn parse_events(&self, data: &[u8]) -> Result<(Block, Vec<OperationType>), SubscriberError> {
         let event_list: EventList = Self::unpack_data(data);
         let events = event_list.get_events().to_vec();
+        // Handle empty event from sawtooth-settings-tp heartbeat pings
+        if events.is_empty() {
+            return Ok::<(Block, Vec<OperationType>), SubscriberError>((
+                Block {
+                    block_num: 0,
+                    block_id: "".to_string(),
+                },
+                Vec::<OperationType>::new(),
+            ));
+        }
         let block = self.parse_block(&events)?;
         let state_changes = self.parse_state_delta_events(&events)?;
         let mut operations = Vec::<OperationType>::new();

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -33,7 +33,7 @@ impl EventHandler {
         }
         self.data_manager
             .execute_operations_in_block(operations, &block)?;
-        info!("Successfully submited event data to reporting database");
+        info!("Successfully submitted event data to reporting database");
         Ok(())
     }
 

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -88,7 +88,7 @@ impl EventHandler {
             .last()
             .unwrap_or_else(|| {
                 Err(SubscriberError::EventParseError(
-                    "No block event found".to_string(),
+                    "Could not parse block event".to_string(),
                 ))
             })
     }


### PR DESCRIPTION
## Proposed change/fix

Updating sawtooth components (`validator`, `settings-tp`, etc.) to `1.2.4` (the latest `chime` version) will enable by default the `settings-tp` to send heartbeat pings to the `validator` every 10s. The `state-delta-subscriber` crashes when these heartbeat pings occur because it cannot parse these "empty" events.

**Fix**: add conditional logic to check for empty events.

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

`docker-compose up` a locally built image of this change in the [compose repo](https://github.com/target/consensource-compose) with the `validator` and `settings-tp` set to version `1.2.4`
