### PR TITLE
Add Assertion support

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,14 +25,6 @@ impl std::fmt::Display for SubscriberError {
 
 impl std::error::Error for SubscriberError {
     #[cfg_attr(tarpaulin, skip)]
-    fn description(&self) -> &str {
-        match *self {
-            SubscriberError::ConnError(ref err) => err,
-            SubscriberError::EventParseError(ref err) => err,
-            SubscriberError::DBError(ref err) => err.description(),
-        }
-    }
-    #[cfg_attr(tarpaulin, skip)]
     fn cause(&self) -> Option<&dyn std::error::Error> {
         match *self {
             SubscriberError::ConnError(_) => None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ fn main() {
     let _logger = match matches.occurrences_of("verbose") {
         1 => simple_logger::init_with_level(LogLevel::Info),
         2 => simple_logger::init_with_level(LogLevel::Debug),
-        0 | _ => simple_logger::init_with_level(LogLevel::Warn),
+        _ => simple_logger::init_with_level(LogLevel::Warn),
     };
 
     let dsn = format!(


### PR DESCRIPTION
## Proposed change/fix
**Note**: Depends on [this pr](https://github.com/target/consensource-database/pull/7)

- Add Assertion arm to AddressSpace match in parse_operation
- Add INGESTION org type
- Implement FromStateAtBlock for NewAssertion, along with containerize!
- Add unit test for assertion
- Remove into_iter calls, Error description impl, redundant verbose match

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

`clip`
`cargo test`
